### PR TITLE
Discover additional JDKs on Windows (#140)

### DIFF
--- a/src/main/java/org/apache/maven/plugins/toolchain/jdk/ToolchainDiscoverer.java
+++ b/src/main/java/org/apache/maven/plugins/toolchain/jdk/ToolchainDiscoverer.java
@@ -443,7 +443,11 @@ public class ToolchainDiscoverer {
             installedDirs.add(userHome.resolve("Library/Java/JavaVirtualMachines"));
             installedDirs.add(userHome.resolve("hostedtoolcache"));
         } else if (win) {
+            installedDirs.add(Paths.get("C:\\Program Files\\Amazon Corretto\\"));
+            installedDirs.add(Paths.get("C:\\Program Files\\BellSoft\\"));
+            installedDirs.add(Paths.get("C:\\Program Files\\Eclipse Adoptium\\"));
             installedDirs.add(Paths.get("C:\\Program Files\\Java\\"));
+            installedDirs.add(Paths.get("C:\\Program Files\\Zulu\\"));
             installedDirs.add(Paths.get("C:\\hostedtoolcache\\windows\\"));
             Path scoop = userHome.resolve("scoop").resolve("apps");
             if (Files.isDirectory(scoop)) {


### PR DESCRIPTION
Adds support for auto-discovery of additional popular JDKs on Windows. Vendors of JDKs for Windows apparently pick their own (default) location to install into and do not re-use the Oracle default of `C:\Program Files\Java`.

This adds support for automatically discovering the following OpenJDK implementations:

- Amazon Corretto
- Azul Zulu
- BellSoft Liberica
- Eclipse Adoptium

Fixes #140

Additional comments:

Gradle & e.g. JetBrains' IDEs both use the Windows registry to look up JDK locations. However, adding support for that would have:

- changed the existing simple implementation a lot
- introduced a sizeable amount of Windows platform code
- not yielded a lot of benefit, see attached screenshot for what a registry looks like after installing a variety of JDKs
  - in particular: the registry key structure is non-consistent across vendors, leading to a lot of extra steps to parse as many as possible
  - occasionally existing keys (particularly the Oracle Java defaults) are overwritten by other vendors (usually selected optionally in the installers), leading to missed detections compared to simple file system checks
  - some vendors (e.g. Amazon) do not create their custom registry keys at all

<img width="1720" height="1361" alt="Screenshot 2026-02-14 at 16 16 19" src="https://github.com/user-attachments/assets/4d7aa300-0ce0-4202-8907-5ee95168cbf6" />

I picked a "random" selection of OpenJDK Vendors that came to mind for this. If other vendors (e.g. Microsoft, IBM (OpenJ9), …) are of interest I can check them out and add them as well.

The implementation is "naive" (just add the folders to scan) on purpose to keep things simple.

---

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
