### PR TITLE
Fix matching against one of multiple env-variables pointing to one JDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@ under the License.
     <javaVersion>8</javaVersion>
     <mavenVersion>3.9.16</mavenVersion>
     <project.build.outputTimestamp>2024-04-18T00:34:08Z</project.build.outputTimestamp>
+    <!-- property used in src/it/select-jdk-env-multi/invoker.properties -->
     <JAVA_HOME>${env.JAVA_HOME}</JAVA_HOME>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@ under the License.
     <javaVersion>8</javaVersion>
     <mavenVersion>3.9.16</mavenVersion>
     <project.build.outputTimestamp>2024-04-18T00:34:08Z</project.build.outputTimestamp>
+    <JAVA_HOME>${env.JAVA_HOME}</JAVA_HOME>
   </properties>
 
   <dependencies>

--- a/src/it/select-jdk-env-multi/invoker.properties
+++ b/src/it/select-jdk-env-multi/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = compile
+invoker.environmentVariables.JAVA_X_HOME = ${JAVA_HOME}
+invoker.environmentVariables.JAVA_Y_HOME = ${JAVA_HOME}

--- a/src/it/select-jdk-env-multi/pom.xml
+++ b/src/it/select-jdk-env-multi/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.toolchains.its</groupId>
+  <artifactId>select-jdk-env-multi</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>maven-toolchains-plugin IT: select jdk toolchain test with environment variable</name>
+  <description>Check that jdk toolchain can be selected when multiple environment variables are used</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <env>JAVA_X_HOME</env>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>select-jdk-toolchain</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/main/java/org/apache/maven/plugins/toolchain/jdk/SelectJdkToolchainMojo.java
+++ b/src/main/java/org/apache/maven/plugins/toolchain/jdk/SelectJdkToolchainMojo.java
@@ -255,7 +255,7 @@ public class SelectJdkToolchainMojo extends AbstractMojo {
             case VERSION:
                 return RequirementMatcherFactory.createVersionMatcher(tcVal).matches(reqVal);
             case ENV:
-                return reqVal.matches("(.*,|^)\\Q" + tcVal + "\\E(,.*|$)");
+                return tcVal.matches("(.*,|^)\\Q" + reqVal + "\\E(,.*|$)");
             default:
                 return RequirementMatcherFactory.createExactMatcher(tcVal).matches(reqVal);
         }


### PR DESCRIPTION
The arguments when matching the collected env-variables pointing to one JDK against the required one were mistakenly swapped. This had the effect that the 'env'-variable match always failed when more than one env variable points to the same JDK.

This happens if in an environment multiple JDKs are available through structured environment variables (e.g. `JAVA_17_HOME`, `JAVA_21_HOME`, `JAVA_25_HOME`) and one of them is used as 'main' JDK and therefore JAVA_HOME also points to it.

As long as only one env variable points to a JDK, this error does not make a difference.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
