### PR TITLE
enable build with Maven 4

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,3 +25,5 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
+    with:
+      maven4-enabled: true


### PR DESCRIPTION
 IT failure:
```
[INFO] -------------------------------------------------
[INFO] Build Summary:
[INFO]   Passed: 6, Failed: 1, Errors: 0, Skipped: 0
[INFO] -------------------------------------------------
[ERROR] The following builds failed:
[ERROR] *  use-custom-toolchain/pom.xml
[INFO] -------------------------------------------------
```

```
Caused by: java.lang.NoSuchMethodError: 'void org.apache.maven.toolchain.DefaultToolchain.<init>(org.apache.maven.toolchain.model.ToolchainModel, java.lang.String, org.codehaus.plexus.logging.Logger)'
    at org.apache.maven.plugins.toolchains.its.custom.CustomToolchainImpl.<init>(CustomToolchainImpl.java:37)
    at org.apache.maven.plugins.toolchains.its.custom.CustomToolchainFactory.createToolchain(CustomToolchainFactory.java:61)
    at org.apache.maven.toolchain.ToolchainManagerFactory$2.createToolchain(ToolchainManagerFactory.java:142)
    at org.apache.maven.impl.DefaultToolchainManager.createToolchain(DefaultToolchainManager.java:106)
```

to be fixed in Maven 4 https://github.com/apache/maven/issues/11973