### PR TITLE
Fix Maven site links in See Also menu

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -42,8 +42,8 @@ under the License.
       <item name="Download" href="download.html"/>
     </menu>
     <menu name="See Also">
-      <item name="Guide to Using Toolchains" href="/guides/mini/guide-using-toolchains.html"/>
-      <item name="Toolchains Descriptor" href="/ref/current/maven-core/toolchains.html"/>
+      <item name="Guide to Using Toolchains" href="../../guides/mini/guide-using-toolchains.html"/>
+      <item name="Toolchains Descriptor" href="../../ref/current/maven-core/toolchains.html"/>
     </menu>
   </body>
 </project>


### PR DESCRIPTION
## Summary

- Update the "See Also" links in `src/site/site.xml` so they resolve correctly from the plugin site.
- Fix the broken "Guide to Using Toolchains" link reported in #57.

## Verification

- `xmllint --noout src/site/site.xml`
- `git diff --check`
- Confirmed `https://maven.apache.org/guides/mini/guide-using-toolchains.html` returns 200.
- Confirmed `https://maven.apache.org/ref/current/maven-core/toolchains.html` resolves to the current Maven reference page and returns 200.

Fixes #57
