### PR TITLE
Fix version comparator: use numeric comparison instead of lexicographic string comparison (#166)

### DIFF
--- a/src/main/java/org/apache/maven/plugins/toolchain/jdk/ToolchainDiscoverer.java
+++ b/src/main/java/org/apache/maven/plugins/toolchain/jdk/ToolchainDiscoverer.java
@@ -370,22 +370,23 @@ public class ToolchainDiscoverer {
                     String[] b = v2.split("\\.");
                     int length = Math.min(a.length, b.length);
                     for (int i = 0; i < length; i++) {
-                        String oa = a[i];
-                        String ob = b[i];
-                        if (!Objects.equals(oa, ob)) {
-                            // A null element is less than a non-null element
-                            if (oa == null || ob == null) {
-                                return oa == null ? -1 : 1;
-                            }
-                            int v = oa.compareTo(ob);
-                            if (v != 0) {
-                                return v;
-                            }
+                        int oa = parseInt(a[i]);
+                        int ob = parseInt(b[i]);
+                        if (oa != ob) {
+                            return Integer.compare(oa, ob);
                         }
                     }
-                    return a.length - b.length;
+                    return Integer.compare(a.length, b.length);
                 })
                 .reversed();
+    }
+
+    private static int parseInt(String s) {
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     private Set<Path> findJdks() {

--- a/src/test/java/org/apache/maven/plugins/toolchain/jdk/ToolchainDiscovererTest.java
+++ b/src/test/java/org/apache/maven/plugins/toolchain/jdk/ToolchainDiscovererTest.java
@@ -18,7 +18,11 @@
  */
 package org.apache.maven.plugins.toolchain.jdk;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.maven.toolchain.model.PersistedToolchains;
+import org.apache.maven.toolchain.model.ToolchainModel;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
@@ -27,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.maven.plugins.toolchain.jdk.ToolchainDiscoverer.CURRENT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -50,5 +55,33 @@ public class ToolchainDiscovererTest {
 
         assertTrue(persistedToolchains.getToolchains().stream()
                 .anyMatch(tc -> tc.getProvides().containsKey(CURRENT)));
+    }
+
+    @Test
+    void testVersionComparator() {
+        ToolchainDiscoverer discoverer = new ToolchainDiscoverer();
+
+        ToolchainModel jdk8 = new ToolchainModel();
+        jdk8.setType("jdk");
+        jdk8.addProvide("version", "8");
+
+        ToolchainModel jdk11 = new ToolchainModel();
+        jdk11.setType("jdk");
+        jdk11.addProvide("version", "11");
+
+        ToolchainModel jdk17 = new ToolchainModel();
+        jdk17.setType("jdk");
+        jdk17.addProvide("version", "17");
+
+        List<ToolchainModel> list = new ArrayList<>();
+        list.add(jdk8);
+        list.add(jdk17);
+        list.add(jdk11);
+
+        list.sort(discoverer.version());
+
+        assertEquals("17", list.get(0).getProvides().getProperty("version"));
+        assertEquals("11", list.get(1).getProvides().getProperty("version"));
+        assertEquals("8", list.get(2).getProvides().getProperty("version"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #166

The `version()` comparator in `ToolchainDiscoverer` used `String.compareTo()` for version segment comparison, which produces incorrect ordering for versions with different digit counts. For example, "8" was sorted before "11" and "17" because '8' > '1' lexicographically, and the reversed order incorrectly promoted JDK 8 over JDK 11/17.

## Changes

- **ToolchainDiscoverer.java**: Replace `String.compareTo()` with `Integer.parseInt()` + `Integer.compare()` in the `version()` comparator for proper numeric version segment comparison
- **ToolchainDiscovererTest.java**: Add `testVersionComparator()` test that verifies correct descending version ordering: 17 > 11 > 8

## Testing

1. Added unit test `testVersionComparator()` that creates ToolchainModel objects with versions "8", "11", "17" and asserts descending sort order
2. Test confirmed failing before the fix: `expected: <17> but was: <8>`
3. Test passes after the fix