### PR TITLE
Revert accidental direct push of version comparator fix

### DIFF
--- a/src/main/java/org/apache/maven/plugins/toolchain/jdk/ToolchainDiscoverer.java
+++ b/src/main/java/org/apache/maven/plugins/toolchain/jdk/ToolchainDiscoverer.java
@@ -370,23 +370,22 @@ public class ToolchainDiscoverer {
                     String[] b = v2.split("\\.");
                     int length = Math.min(a.length, b.length);
                     for (int i = 0; i < length; i++) {
-                        int oa = parseInt(a[i]);
-                        int ob = parseInt(b[i]);
-                        if (oa != ob) {
-                            return Integer.compare(oa, ob);
+                        String oa = a[i];
+                        String ob = b[i];
+                        if (!Objects.equals(oa, ob)) {
+                            // A null element is less than a non-null element
+                            if (oa == null || ob == null) {
+                                return oa == null ? -1 : 1;
+                            }
+                            int v = oa.compareTo(ob);
+                            if (v != 0) {
+                                return v;
+                            }
                         }
                     }
-                    return Integer.compare(a.length, b.length);
+                    return a.length - b.length;
                 })
                 .reversed();
-    }
-
-    private static int parseInt(String s) {
-        try {
-            return Integer.parseInt(s);
-        } catch (NumberFormatException e) {
-            return 0;
-        }
     }
 
     private Set<Path> findJdks() {

--- a/src/test/java/org/apache/maven/plugins/toolchain/jdk/ToolchainDiscovererTest.java
+++ b/src/test/java/org/apache/maven/plugins/toolchain/jdk/ToolchainDiscovererTest.java
@@ -18,11 +18,7 @@
  */
 package org.apache.maven.plugins.toolchain.jdk;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.maven.toolchain.model.PersistedToolchains;
-import org.apache.maven.toolchain.model.ToolchainModel;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
@@ -31,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.maven.plugins.toolchain.jdk.ToolchainDiscoverer.CURRENT;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -55,33 +50,5 @@ public class ToolchainDiscovererTest {
 
         assertTrue(persistedToolchains.getToolchains().stream()
                 .anyMatch(tc -> tc.getProvides().containsKey(CURRENT)));
-    }
-
-    @Test
-    void testVersionComparator() {
-        ToolchainDiscoverer discoverer = new ToolchainDiscoverer();
-
-        ToolchainModel jdk8 = new ToolchainModel();
-        jdk8.setType("jdk");
-        jdk8.addProvide("version", "8");
-
-        ToolchainModel jdk11 = new ToolchainModel();
-        jdk11.setType("jdk");
-        jdk11.addProvide("version", "11");
-
-        ToolchainModel jdk17 = new ToolchainModel();
-        jdk17.setType("jdk");
-        jdk17.addProvide("version", "17");
-
-        List<ToolchainModel> list = new ArrayList<>();
-        list.add(jdk8);
-        list.add(jdk17);
-        list.add(jdk11);
-
-        list.sort(discoverer.version());
-
-        assertEquals("17", list.get(0).getProvides().getProperty("version"));
-        assertEquals("11", list.get(1).getProvides().getProperty("version"));
-        assertEquals("8", list.get(2).getProvides().getProperty("version"));
     }
 }

--- a/src/test/java/org/apache/maven/plugins/toolchain/jdk/ToolchainDiscovererTest.java
+++ b/src/test/java/org/apache/maven/plugins/toolchain/jdk/ToolchainDiscovererTest.java
@@ -84,38 +84,4 @@ public class ToolchainDiscovererTest {
         assertEquals("11", list.get(1).getProvides().getProperty("version"));
         assertEquals("8", list.get(2).getProvides().getProperty("version"));
     }
-
-    @Test
-    void testVersionComparatorMultiPart() {
-        ToolchainDiscoverer discoverer = new ToolchainDiscoverer();
-
-        ToolchainModel v1 = new ToolchainModel();
-        v1.setType("jdk");
-        v1.addProvide("version", "11.0.1");
-
-        ToolchainModel v2 = new ToolchainModel();
-        v2.setType("jdk");
-        v2.addProvide("version", "11.0.31");
-
-        ToolchainModel v3 = new ToolchainModel();
-        v3.setType("jdk");
-        v3.addProvide("version", "17.0.1");
-
-        ToolchainModel v4 = new ToolchainModel();
-        v4.setType("jdk");
-        v4.addProvide("version", "1.8");
-
-        List<ToolchainModel> list = new ArrayList<>();
-        list.add(v1);
-        list.add(v2);
-        list.add(v3);
-        list.add(v4);
-
-        list.sort(discoverer.version());
-
-        assertEquals("17.0.1", list.get(0).getProvides().getProperty("version"));
-        assertEquals("11.0.31", list.get(1).getProvides().getProperty("version"));
-        assertEquals("11.0.1", list.get(2).getProvides().getProperty("version"));
-        assertEquals("1.8", list.get(3).getProvides().getProperty("version"));
-    }
 }


### PR DESCRIPTION
This reverts two commits that were accidentally pushed directly to master:

- Reverts 5d385b6 (Fix version comparator: use numeric comparison)
- Reverts b83d216 (Expand version comparator test)

These changes should go through proper PR review before being merged. Reverting to restore master to its state before the accidental push.

See discussion on #166.