### PR TITLE
Remove unnecessary static synchronization in ToolchainMojo

### DIFF
--- a/src/main/java/org/apache/maven/plugins/toolchain/ToolchainMojo.java
+++ b/src/main/java/org/apache/maven/plugins/toolchain/ToolchainMojo.java
@@ -46,8 +46,6 @@ import org.apache.maven.toolchain.ToolchainPrivate;
         configurator = "toolchains-requirement-configurator",
         threadSafe = true)
 public class ToolchainMojo extends AbstractMojo {
-    private static final Object LOCK = new Object();
-
     /**
      */
     @Component
@@ -144,9 +142,7 @@ public class ToolchainMojo extends AbstractMojo {
                     getLog().info("Found matching toolchain for type " + type + ": " + tc);
 
                     // store matching toolchain to build context
-                    synchronized (LOCK) {
-                        toolchainManagerPrivate.storeToolchainToBuildContext(tc, session);
-                    }
+                    toolchainManagerPrivate.storeToolchainToBuildContext(tc, session);
 
                     return true;
                 }


### PR DESCRIPTION
Fixes #174

## Problem

The static `LOCK` object and `synchronized` block around `toolchainManagerPrivate.storeToolchainToBuildContext()` are unnecessary:

1. The plugin is marked `threadSafe=true`, meaning Maven may execute it concurrently for different modules/sessions
2. `storeToolchainToBuildContext()` stores data into the build context, which is already per-session and thread-safe
3. The static lock introduces unnecessary contention: one module's toolchain selection blocks another unrelated module's selection, defeating the purpose of `threadSafe=true`

## Impact

In multi-module Maven builds where the toolchains plugin runs in multiple modules (e.g., via inherited plugin configuration), the static lock serializes what could otherwise run in parallel, slowing down builds.

## Fix

Remove the `private static final Object LOCK` field and the `synchronized (LOCK)` block around the `storeToolchainToBuildContext` call, since it provides no benefit.