### PR TITLE
Fix env property example in JDK discovery docs

### DIFF
--- a/src/site/apt/toolchains/jdk-discovery.apt.vm
+++ b/src/site/apt/toolchains/jdk-discovery.apt.vm
@@ -97,8 +97,8 @@ JDK Toolchain discovery mechanism
 
 +---+
 <properties>
-  <toolchain.jdk.version>JAVA17_HOME</toolchain.jdk.version>
-<properties>
+  <toolchain.jdk.env>JAVA17_HOME</toolchain.jdk.env>
+</properties>
 +---+
 
   You can also do everything only at CLI level, without modifying your <<<pom.xml>>>

--- a/src/site/apt/toolchains/jdk-discovery.apt.vm
+++ b/src/site/apt/toolchains/jdk-discovery.apt.vm
@@ -76,7 +76,7 @@ JDK Toolchain discovery mechanism
 +---+
 <properties>
   <toolchain.jdk.version>[17,)</toolchain.jdk.version>
-<properties>
+</properties>
 
 <plugin>
   <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The example for selecting a toolchain by environment variable incorrectly used `<toolchain.jdk.version>` instead of `<toolchain.jdk.env>`. Also fixes malformed XML closing tag.