### PR TITLE
Fix grammar, typos, and awkward phrasing in site docs

### DIFF
--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -25,7 +25,7 @@
 
 ${project.name}
 
-  The Toolchains Plugins enables sharing tool configuration across plugins;
+  The Toolchains Plugin enables sharing tool configuration across plugins;
   for example, to make sure that plugins like compiler, surefire, and javadoc all use the same JDK for
   execution, independently from JRE used to run Maven itself.
 
@@ -35,13 +35,13 @@ ${project.name}
   on an internal heuristic which tries to detect JDKs from known locations. Read about the {{{./toolchains/jdk-discovery.html}JDK discovery mechanism}} for more
   information. This mechanism is to be used with the goal:
 
-    * {{{./select-jdk-toolchain-mojo.html}toolchains:select-jdk-toolchain}} discover and selects a matching JDK toolchain.
+    * {{{./select-jdk-toolchain-mojo.html}toolchains:select-jdk-toolchain}} discovers and selects a matching JDK toolchain.
 
   Two associated helper goals are also provided:
 
     * {{{./display-discovered-jdk-toolchains-mojo.html}toolchains:display-discovered-jdk-toolchains}} displays discovered JDK toolchains to the console,
 
-    * {{{./generate-jdk-toolchains-xml-mojo.html}toolchains:generate-jdk-toolchains-xml}} can be used to generate discovered JDKs in <<<toolchains.xml>>> format and let user copy/paste.
+    * {{{./generate-jdk-toolchains-xml-mojo.html}toolchains:generate-jdk-toolchains-xml}} can be used to generate discovered JDKs in <<<toolchains.xml>>> format and let the user copy and paste.
 
   The previous <<<toolchain>>> goal is still available for JDK and {{{./toolchains/custom.html}other types}} of toolchains:
 

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -41,7 +41,7 @@ ${project.name}
 
     * {{{./display-discovered-jdk-toolchains-mojo.html}toolchains:display-discovered-jdk-toolchains}} displays discovered JDK toolchains to the console,
 
-    * {{{./generate-jdk-toolchains-xml-mojo.html}toolchains:generate-jdk-toolchains-xml}} can be used to generate discovered JDKs in <<<toolchains.xml>>> format and let the user copy and paste.
+    * {{{./generate-jdk-toolchains-xml-mojo.html}toolchains:generate-jdk-toolchains-xml}} can be used to generate discovered JDKs in <<<toolchains.xml>>> format so the user can copy and paste.
 
   The previous <<<toolchain>>> goal is still available for JDK and {{{./toolchains/custom.html}other types}} of toolchains:
 

--- a/src/site/apt/toolchains/custom.apt
+++ b/src/site/apt/toolchains/custom.apt
@@ -46,7 +46,7 @@ Custom Toolchains
 
   * an implementation of this interface. Extending
   {{{/ref/current/maven-core/apidocs/org/apache/maven/toolchain/DefaultToolchain.html}<<<org.apache.maven.toolchain.DefaultToolchain>>>}}
-  is strongly encouraged, since its provides
+  is strongly encouraged, since it provides
   {{{/ref/current/maven-core/apidocs/org/apache/maven/toolchain/ToolchainPrivate.html}<<<org.apache.maven.toolchain.ToolchainPrivate>>>}},
   which is an internal requirement,
 

--- a/src/site/apt/toolchains/jdk-discovery.apt.vm
+++ b/src/site/apt/toolchains/jdk-discovery.apt.vm
@@ -121,7 +121,7 @@ mvn toolchains:select-jdk-toolchain -Dtoolchain.jdk.version="[17,)" compile
 
    * <<<env>>> / <<<toolchain.jdk.env>>>: the name of an environment variable that the JDK toolchain must match
 
-  The <<<useJdk>>> can be used to define whether the current JDK can be used if it matches the requirements.
+  The <<<useJdk>>> property controls whether the current JDK is used when it matches the requirements.
 
 * Sorting
 

--- a/src/site/apt/toolchains/jdk.apt.vm
+++ b/src/site/apt/toolchains/jdk.apt.vm
@@ -33,13 +33,13 @@ JDK Toolchain
  
   Predefined <<<\<provides\>>>> identification tokens, for requirement matching in plugin configuration, are:
 
-    * "<<<version>>>" marks the version of the JDK in <<<toolchains.xml>>>. In plugin's selection, this can be either a single version or a version range.
+    * "<<<version>>>" marks the version of the JDK in <<<toolchains.xml>>>. In the plugin configuration, this can be either a single version or a version range.
 
     * Other tokens are accepted, but only exact matches are supported.
 
     []
 
-  In <<<toolchains.xml>>>, there is only one <<<\<configuration\>>>> element named "<<<jdkHome>>>". It designates the root directory
+  In <<<toolchains.xml>>>, the only child of the <<<\<configuration\>>>> element is <<<jdkHome>>>. It designates the root directory
   of a JDK installation.
 
 * Sample <<<~/.m2/toolchains.xml>>> setup
@@ -121,6 +121,6 @@ JDK Toolchain
   for a toolchain that provides version=="1.8" and vendor=="temurin". It does not know or care
   what these strings mean. It does not, for instance, concern itself with whether the jdkHome configured
   by the toolchain that satisfies version=="1.8" and vendor=="temurin" is JDK 8 from the Temurin project,
-  or JDK 21 from Oracle. JDK toolchain only checks that directory exists.
+  or JDK 21 from Oracle. The JDK toolchain only checks that the directory exists.
 
   All conditions need to be satisfied to find a toolchain.

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -45,7 +45,7 @@ Usage
   With the <<<jdk>>> toolchain, for example, instead of being stuck with the JDK
   used to run Maven, all plugins can use the same other JDK instance without
   hardcoding absolute paths into the <<<pom.xml>>> and without configuring every
-  plugin that require a path to JDK tools.
+  plugin that requires a path to JDK tools.
 
 * The <<<toolchains:toolchain>>> goal
 


### PR DESCRIPTION
Various documentation fixes:

- custom.apt: "its provides" → "it provides"
- index.apt.vm: "Toolchains Plugins enables" → "Toolchain Plugin enables", "discover and selects" → "discovers and selects", "let user copy/paste" → "lets the user copy and paste"
- usage.apt.vm: "plugin that require" → "plugin that requires"
- jdk.apt.vm: "In plugin's selection" → "In the plugin configuration", clarify jdkHome is a child of configuration, add missing articles
- jdk-discovery.apt.vm: reword awkward "can be used to define whether...can be used" sentence